### PR TITLE
Compatibility for Craft 3.2+ added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 - 2020-03-25
+### Changed
+- Field sync updated for Craft ^3.2
+### Fixed
+- ID comparison between string and int now correctly compares only in int type
+
 ## 1.0.3 - 2019-04-09
 ### Fixed
 - Fixed Matrix/Neo/SuperTable syncing after 1.0.0-beta.1 checked for permissions (thanks @jesuismaxime)

--- a/src/models/Syncable.php
+++ b/src/models/Syncable.php
@@ -124,6 +124,10 @@ class Syncable extends \craft\base\Model
             return false;
         }
 
+		if (\array_key_exists('fields', $updates)) {
+            $siteElement->setFieldValues($updates['fields']);
+            unset($updates['fields']);
+		}
         Craft::configure($siteElement, $updates);
 
         // Don't bother validating custom fields for other sites
@@ -169,12 +173,13 @@ class Syncable extends \craft\base\Model
         $updates = [];
 
         if ($this->hasSource(self::SOURCE_FIELDS)) {
+            $updates['fields'] = [];
             if ($this->overwrite) {
-                $updates = $this->element->getFieldValues();
+                $updates['fields'] = $this->element->getFieldValues();
             } else {
                 foreach ($this->getTranslatableFieldHandles($this->element) as $handle) {
                     if ($savedElement->getSerializedFieldValues([$handle]) === $siteElement->getSerializedFieldValues([$handle])) {
-                        $updates[$handle] = $this->element->{$handle};
+                        $updates['fields'][$handle] = $this->element->{$handle};
                     }
                 }
             }

--- a/src/models/Syncable.php
+++ b/src/models/Syncable.php
@@ -106,7 +106,7 @@ class Syncable extends \craft\base\Model
     public function propagateToSite(int $siteId): bool
     {
         if (!$this->enabled ||
-            $this->element->siteId === $siteId ||
+            (int)($this->element->siteId) === $siteId ||
             !$this->element->id
         ) {
             return false;
@@ -165,7 +165,7 @@ class Syncable extends \craft\base\Model
 
     private function getUpdatesForElement(Element $siteElement): array
     {
-        $savedElement = Craft::$app->getElements()->getElementById($this->element->id, get_class($this->element), $this->element->siteId);
+        $savedElement = Craft::$app->getElements()->getElementById($this->element->id, get_class($this->element), (int)($this->element->siteId));
         $updates = [];
 
         if ($this->hasSource(self::SOURCE_FIELDS)) {


### PR DESCRIPTION
Hi

I have found a bug in the plugin, which prevents field values from updating with newer Craft versions.

The changes in this pull request will make it work again (tested on Craft 3.4.10.1).

Cheers
Peter